### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,7 +103,7 @@ dependencies {
   compile group: 'cglib', name: 'cglib', version:'3.1'
   compile group: 'commons-beanutils', name: 'commons-beanutils', version:'1.9.2'
   compile group: 'commons-codec', name: 'commons-codec', version:'1.10'
-  compile group: 'commons-collections', name: 'commons-collections', version:'3.2.1'
+  compile group: 'commons-collections', name: 'commons-collections', version:'3.2.2'
   compile group: 'commons-dbcp', name: 'commons-dbcp', version:'1.4'
   compile group: 'org.apache.commons', name: 'commons-digester3', version:'3.2'
   compile group: 'commons-fileupload', name: 'commons-fileupload', version:'1.3.1'


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/