### PR TITLE
Fix for Angular dependency problem

### DIFF
--- a/www/bower.json
+++ b/www/bower.json
@@ -44,7 +44,8 @@
     "angular-loading-bar": "~0.6.0",
     "angular-translate": "~2.7.0",
     "angular-translate-loader-partial": "~2.7.0",
-    "angular-cookies": "~1.3.15"
+    "angular-cookies": "~1.3.15",
+    "angular-animate": "1.3.20"
   },
   "overrides": {
     "font-awesome": {


### PR DESCRIPTION
Fix for Angular dependency version problem. When using Angular 1.3.20 you need to make shure your angular-animate version is also locked to 1.3.20:
http://forums.openspecimen.org/t/javascript-problem-with-openspecimen-4-gui-not-loading/935/2