### PR TITLE
Bug fix: Pressing enter on any other input field causes datepicker fie…

### DIFF
--- a/www/app/modules/common/datepicker.html
+++ b/www/app/modules/common/datepicker.html
@@ -3,7 +3,7 @@
     <div class="input-group os-date-picker">
       <input type="text" class="form-control" show-button-bar="true" is-open="datePicker.isOpen">
       <span class="input-group-btn">
-        <button class="btn btn-default" ng-click="showDatePicker()" tabindex="-1">
+        <button type="button" class="btn btn-default" ng-click="showDatePicker()" tabindex="-1">
           <span class="fa fa-calendar"></span>
         </button>
       </span>


### PR DESCRIPTION
Bug: Pressing enter on any other input field causes datepicker field to populate with current date.
Solution: Add "type="button"" to the calendar picker button
References: http://plnkr.co/edit/9mq6W6XfoGK2vDP4PZLA?p=preview
https://github.com/angular-ui/bootstrap/issues/1275