### PR TITLE
Fix build https error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ sourceSets {
 description = "openspecimen"
 
 repositories {
-  maven { url "http://repo.maven.apache.org/maven2" }
+  maven { url "https://repo.maven.apache.org/maven2" }
 }
 
 configurations {


### PR DESCRIPTION
Hello,

Since the January 15th, the gradle build fails with 501 errors on all dependencies.

According to [here](https://stackoverflow.com/questions/59763531/maven-dependencies-are-failing-with-a-501-error), the url for Maven should be changed to https in build.gradle. This PR changes that.

(However, I'm afraid this changed should be push to all other active branches..)