### PR TITLE
Fix two compilation errors

### DIFF
--- a/www/app/modules/administrative/job/search.html
+++ b/www/app/modules/administrative/job/search.html
@@ -14,7 +14,7 @@
 
       <div class="form-group">
         <os-select os-md-input ng-model="filterOpts.type" list="types"
-          select-prop="type" display-prop="caption" class=form-control"
+          select-prop="type" display-prop="caption" class="form-control"
           placeholder="{{'jobs.type' | translate}}">
         </os-select>
       </div>

--- a/www/app/modules/query/column-filter.html
+++ b/www/app/modules/query/column-filter.html
@@ -3,8 +3,8 @@
   ng-class="{ 'ngSorted': !noSortVisible }">
 
   <div ng-click="col.sort($event)" 
-    ng-class="'colt' + col.index" class="ngHeaderText">
-    <tooltip-append-to-body="true" tooltip="{{col.displayName}}" tooltip-placement="bottom">
+    ng-class="'colt' + col.index" class="ngHeaderText"
+    tooltip-append-to-body="true" tooltip="{{col.displayName}}" tooltip-placement="bottom">
     {{col.displayName}}
   </div>
   


### PR DESCRIPTION
Two exceptions occurred during compilation

### first
```html
Warning: dist/modules/administrative/job/search.html
Error: Parse Error: <os-select os-md-input ng-model="filterOpts.type" list="types"
          select-prop="type" display-prop="caption" class=form-control"
          placeholder="{{'jobs.type' | translate}}">
        </os-select>
      </div>

      <os-clear-filters opts="filterOpts"></os-clear-filters>
    </div>
  </div>

  <os-list-page-size opts="pagerOpts" on-change="pageSizeChanged()"></os-list-page-size>
</div>  Use --force to continue.

Aborted due to warnings.
```

### second
```html
Warning: dist/modules/query/column-filter.html
Error: Parse Error: <tooltip-append-to-body="true" tooltip="{{col.displayName}}" tooltip-placement="bottom">
    {{col.displayName}}
  </div>

  <div class="ngSortButtonDown" ng-show="col.showSortButtonDown()"></div>
  <div class="ngSortButtonUp" ng-show="col.showSortButtonUp()"></div>

  <div class="ngSortPriority">{{col.sortPriority}}</div>
  <div ng-class="{ ngPinnedIcon: col.pinned, ngUnPinnedIcon: !col.pinned }" ng-click="togglePin(col)" ng-show="col.pinnable"></div>
</div>

<!-- input type="text" class="form-control"
   ng-click="stopClickProp($event)"
   placeholder="Filter ..." ng-model="col.filterText"
   ng-style="{ 'width' : col.width - 10 + 'px' }"
   style="position: absolute; top: 30px; bottom: 30px; left: 5px; bottom:0;"/ -->

<div style="position: absolute; top: 36px; border-top: 1px solid #ccc; padding: 5px; width: 100%;"
  ng-if="col.colDef.showSummary">
  <span>{{col.colDef.summary}}</span>
</div>

<div ng-show="col.resizable"
  class="ngHeaderGrip"
  ng-click="col.gripClick($event)"
  ng-mousedown="col.gripOnMouseDown($event)">
</div>  Use --force to continue.

Aborted due to warnings.
```